### PR TITLE
Fix README CMS dashboard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ When installing dependencies, ensure you're in the correct directory - either `/
 5. Fill in the necesssary environment variables in both `env.development` files
 6. Run `npm run dev` to start both the website and Sanity Studio locally
 7. Open the website at [localhost:8888](http://localhost:8888)
-8. Open the CMS dashboard at [locahost:3333](https://localhost:3333)
+8. Open the CMS dashboard at [localhost:3333](http://localhost:3333)
 9. Edit the files in `/web` or `/studio` to edit the website or CMS
 
 ### Styling


### PR DESCRIPTION
## Summary
- fix a typo in README when linking to the CMS dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685129389848832682f479e5321ae330