### PR TITLE
Add default description fallback

### DIFF
--- a/web/src/_data/metadata.js
+++ b/web/src/_data/metadata.js
@@ -7,15 +7,18 @@ const DEFAULT_METADATA = {
 }
 
 const getMetaData = async () => {
-  const data = await client
-    .fetch(groq`
+  try {
+    const data = await client.fetch(groq`
     *[_type == "siteSettings"] {
       ...
     }[0]
   `)
-    .catch(() => ({}))
-
-  return { ...DEFAULT_METADATA, ...(data || {}) }
+    return { ...DEFAULT_METADATA, ...(data || {}) }
+  } catch (err) {
+    // eslint-disable-next-line
+    console.error(err)
+    return DEFAULT_METADATA
+  }
 }
 
 module.exports = getMetaData

--- a/web/src/_data/metadata.js
+++ b/web/src/_data/metadata.js
@@ -1,11 +1,21 @@
 const groq = require('groq')
 const client = require('../utils/sanityClient')
 
-const getMetaData = async () =>
-  client.fetch(groq`
+const DEFAULT_METADATA = {
+  description:
+    'Draft & Flow is a community-centred cycle workshop providing repairs, services and route information.'
+}
+
+const getMetaData = async () => {
+  const data = await client
+    .fetch(groq`
     *[_type == "siteSettings"] {
       ...
     }[0]
   `)
+    .catch(() => ({}))
+
+  return { ...DEFAULT_METADATA, ...(data || {}) }
+}
 
 module.exports = getMetaData

--- a/web/src/_includes/layouts/base/head.njk
+++ b/web/src/_includes/layouts/base/head.njk
@@ -49,7 +49,7 @@
     <link rel="stylesheet" href="/css/styles.css">
 
     <meta name="generator" content="Eleventy">
-    <meta name="Description" content="{{ seo.description or description or metadata.description }}">
+    <meta name="description" content="{{ seo.description or description or metadata.description }}">
     <link rel="canonical" href="{{ env.url }}{{ page.url }}" />
     <meta property="fb:app_id" content="369428899362893" />
     <meta property="og:title" content="{{ title or metadata.title | safe }}" />

--- a/web/src/_includes/layouts/base/head.njk
+++ b/web/src/_includes/layouts/base/head.njk
@@ -49,12 +49,12 @@
     <link rel="stylesheet" href="/css/styles.css">
 
     <meta name="generator" content="Eleventy">
-    <meta name="Description" content="{{ description or metadata.description }}">
+    <meta name="Description" content="{{ seo.description or description or metadata.description }}">
     <link rel="canonical" href="{{ env.url }}{{ page.url }}" />
     <meta property="fb:app_id" content="369428899362893" />
     <meta property="og:title" content="{{ title or metadata.title | safe }}" />
     <meta property="og:url" content="{{ env.url }}{{ page.url }}" />
-    <meta property="og:description" content="{{ description or metadata.description }}" />
+    <meta property="og:description" content="{{ seo.description or description or metadata.description }}" />
     {% set ogImage %}{% imageBannerUrlFor banner, 1000 %}{% endset %}
     <meta property="og:image" content="{% if ogImage != "undefined" %}{{ogImage}}{% else %}{{env.url + "/static/logos/draftandflow-square.png" }}{% endif %}" />
     <meta property="og:type" content="article" />

--- a/web/src/_includes/layouts/pages/news/newsArticle.njk
+++ b/web/src/_includes/layouts/pages/news/newsArticle.njk
@@ -54,7 +54,7 @@
     "datePublished": "{{page.date}}",
     "dateCreated": "{{page.date}}",
     "dateModified": "{{ article.updatedAt }}",
-    "description": "{{ description or metadata.description }}",
+    "description": "{{ seo.description or description or metadata.description }}",
     "articleBody": "{{ article.content | striptags(true) }}"
     }
   </script>

--- a/web/src/content/404.html
+++ b/web/src/content/404.html
@@ -3,6 +3,9 @@ title: Oops! Not Found
 permalink: 404.html
 layout: layouts/404.njk
 eleventyExcludeFromCollections: true
+seo:
+  title: Draft & Flow - Page Not Found
+  description: This page couldn't be located. Explore our site for cycling services and info
 ---
 
 Looks like we've sent you on off-route. We can't find this page, please head back to the [homepage](/).

--- a/web/src/content/aberfeldy/courses/course-confirmation-pages.html
+++ b/web/src/content/aberfeldy/courses/course-confirmation-pages.html
@@ -12,6 +12,9 @@ eleventyComputed:
     title: "{{ course.title }}"
     key: "{{ course.title }}"
   title: "{{ course.title }}"
+  seo:
+    title: "Course Confirmed - {{ course.title }}"
+    description: "{{ course.intro }}"
 tags:
   - courses
 permalink: "{{ course.permalink }}confirmed"

--- a/web/src/content/aberfeldy/courses/courses-pages.html
+++ b/web/src/content/aberfeldy/courses/courses-pages.html
@@ -12,6 +12,9 @@ eleventyComputed:
     title: "{{ course.title }}"
     key: "{{ course.title }}"
   title: "{{ course.title }}"
+  seo:
+    title: "{{ course.title }}"
+    description: "{{ course.intro }}"
 tags:
   - courses
 permalink: "{{ course.permalink }}"

--- a/web/src/content/aberfeldy/courses/courses.html
+++ b/web/src/content/aberfeldy/courses/courses.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-local.jpg
 title: Education
 tags:
   - main
+seo:
+  title: Bike Maintenance Courses in Aberfeldy
+  description: Learn to maintain and fix your bike through hands-on courses at Draft & Flow
 eleventyNavigation:
   parent: Local
   key: Courses

--- a/web/src/content/aberfeldy/index.html
+++ b/web/src/content/aberfeldy/index.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-local.jpg
 title: Local
 tags:
   - main
+seo:
+  title: Local Cycling Resources in Aberfeldy
+  description: Discover local cycling routes, services and events around Aberfeldy
 eleventyNavigation:
   key: Local
   title: Local

--- a/web/src/content/aberfeldy/places/places.html
+++ b/web/src/content/aberfeldy/places/places.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-local.jpg
 title: Places To Go
 tags:
   - main
+seo:
+  title: Places To Ride and Visit Around Aberfeldy
+  description: Discover rides, cafes and attractions in and around Aberfeldy, Scotland
 eleventyNavigation:
   parent: Local
   key: Places To Go

--- a/web/src/content/aberfeldy/social-rides/social-rides.html
+++ b/web/src/content/aberfeldy/social-rides/social-rides.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-daftandslow.png
 title: Social Events
 tags:
   - main
+seo:
+  title: Aberfeldy Social Group Rides
+  description: Join local group rides and social cycling events organised by Draft & Flow
 eleventyNavigation:
   parent: Local
   key: Social Events

--- a/web/src/content/about/index.html
+++ b/web/src/content/about/index.html
@@ -5,6 +5,9 @@ pageID: staticPages.about
 title: About
 tags:
   - secondary
+seo:
+  title: About Draft & Flow Community Cycle Workshop
+  description: Learn how Draft & Flow supports cycling in Aberfeldy and beyond
 eleventyNavigation:
   key: About
   title: About

--- a/web/src/content/about/our-team/index.html
+++ b/web/src/content/about/our-team/index.html
@@ -5,6 +5,9 @@ pageID: staticPages.ourTeam
 title: Our Team
 tags:
   - secondary
+seo:
+  title: Meet the Draft & Flow Team
+  description: Get to know the volunteers and directors behind Draft & Flow
 eleventyNavigation:
   key: Our Team
   title: Our Team

--- a/web/src/content/accessibility.html
+++ b/web/src/content/accessibility.html
@@ -2,6 +2,9 @@
 layout: layouts/simple.njk
 tags:
   - tertiary
+seo:
+  title: Accessibility Statement
+  description: Learn how Draft & Flow ensures our website is usable for everyone
 eleventyNavigation:
   key: Accessibility
   title: Accessibility

--- a/web/src/content/bike-servicing/e-bike-servicing/e-bike-servicing.html
+++ b/web/src/content/bike-servicing/e-bike-servicing/e-bike-servicing.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-ebike.jpg
 title: E-bikes
 tags:
   - main
+seo:
+  title: E-Bike Servicing in Aberfeldy
+  description: Professional maintenance and support for your electric bike
 eleventyNavigation:
   parent: Service
   key: E-bikes

--- a/web/src/content/bike-servicing/full-service/full-service.html
+++ b/web/src/content/bike-servicing/full-service/full-service.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-service.jpg
 title: Full-Service Repairs
 tags:
   - main
+seo:
+  title: Full-Service Bike Repairs
+  description: Comprehensive bike repairs and maintenance by qualified mechanics
 eleventyNavigation:
   parent: Service
   key: Full-Service Repairs

--- a/web/src/content/bike-servicing/index.html
+++ b/web/src/content/bike-servicing/index.html
@@ -4,6 +4,9 @@ title: Service
 bannerImage: src/static/images/banner-service.jpg
 tags:
   - main
+seo:
+  title: Bike Servicing & Repairs
+  description: Professional bike services including repairs, upgrades and DIY options
 eleventyNavigation:
   key: Service
   title: Service

--- a/web/src/content/bike-servicing/self-service/self-service.html
+++ b/web/src/content/bike-servicing/self-service/self-service.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-diy.jpg
 title: DIY Repairs
 tags:
   - main
+seo:
+  title: DIY Bike Repair Space
+  description: Use our tools and stands to fix your own bike with optional guidance
 eleventyNavigation:
   parent: Service
   key: DIY Repairs

--- a/web/src/content/bike-servicing/suspension-servicing/suspension-servicing.html
+++ b/web/src/content/bike-servicing/suspension-servicing/suspension-servicing.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-ebike.jpg
 title: Suspension
 tags:
   - main
+seo:
+  title: Suspension Servicing & Repairs
+  description: Keep your suspension forks, shocks and dropper posts running smoothly
 eleventyNavigation:
   parent: Service
   key: Suspension

--- a/web/src/content/bike-servicing/upgrades/upgrades.html
+++ b/web/src/content/bike-servicing/upgrades/upgrades.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-upgrades.jpg
 title: Parts/Upgrades
 tags:
   - main
+seo:
+  title: Bike Parts & Upgrades
+  description: Improve your bike with quality components and professional installation
 eleventyNavigation:
   parent: Service
   key: Upgrades

--- a/web/src/content/bikes/custom-builds/custom-builds.html
+++ b/web/src/content/bikes/custom-builds/custom-builds.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-custom.jpg
 title: Custom Builds
 tags:
   - main
+seo:
+  title: Custom Bike Builds & Wheelsets
+  description: Design your dream bike with fully customised components and wheels
 eleventyNavigation:
   parent: Bikes
   key: Custom Bikes/Wheels

--- a/web/src/content/bikes/index.html
+++ b/web/src/content/bikes/index.html
@@ -5,6 +5,9 @@ bannerImage: src/static/images/banner-bikes.jpg
 tags:
   - main
   - refurbs
+seo:
+  title: Bikes For Sale & Hire
+  description: Browse new bikes, refurbished models and e-bike hire options
 eleventyNavigation:
   key: Bikes
   title: Bikes

--- a/web/src/content/bikes/refurbs/pages-refurbs.html
+++ b/web/src/content/bikes/refurbs/pages-refurbs.html
@@ -13,6 +13,9 @@ eleventyComputed:
   id: "{{ refurb.id }}"
   available: "{{ refurb.available }}"
   title: "{{ refurb.name }}"
+  seo:
+    title: "{{ refurb.name }} | Refurbished Bike"
+    description: "{{ refurb.description | striptags(true) }}"
   eleventyNavigation:
     parent: "Refurbs"
     key: "{{ title }}"

--- a/web/src/content/bikes/refurbs/refurbs.html
+++ b/web/src/content/bikes/refurbs/refurbs.html
@@ -5,6 +5,9 @@ title: Refurbs
 tags:
   - main
   - refurbs
+seo:
+  title: Refurbished Bikes in Aberfeldy
+  description: Affordable refurbished bikes restored for the community
 eleventyNavigation:
   parent: Bikes
   key: Refurbs

--- a/web/src/content/brands/brands.html
+++ b/web/src/content/brands/brands.html
@@ -4,6 +4,9 @@ title: Brands
 tags:
   - secondary
   - brands
+seo:
+  title: Bike Brands We Trust
+  description: Explore premium cycling brands available through Draft & Flow
 eleventyNavigation:
   key: Brands
   title: Brands

--- a/web/src/content/brands/pages-brands.html
+++ b/web/src/content/brands/pages-brands.html
@@ -18,6 +18,9 @@ eleventyComputed:
   theirDescription: "{{ brand.theirDescription }}"
   website: "{{ brand.website }}"
   banner: "{{ brand.banner }}"
+  seo:
+    title: "{{ brand.name }} Bikes & Gear"
+    description: "{{ brand.oneLiner }}"
   review: "{{ brand.review }}"
   eleventyNavigation:
     parent: "Brands"

--- a/web/src/content/contact/contact.html
+++ b/web/src/content/contact/contact.html
@@ -4,6 +4,9 @@ pageID: staticPages.contact
 navtitle: Contact
 tags:
   - secondary
+seo:
+  title: Contact Draft & Flow
+  description: Get in touch with Draft & Flow for bike services, sales and more
 eleventyNavigation:
   key: Contact
   title: Contact

--- a/web/src/content/cookie-policy.html
+++ b/web/src/content/cookie-policy.html
@@ -2,6 +2,9 @@
 layout: layouts/simple.njk
 tags:
   - tertiary
+seo:
+  title: Cookie Policy
+  description: Information about the cookies Draft & Flow uses and why
 eleventyNavigation:
   key: Cookie Policy
   title: Cookie Policy

--- a/web/src/content/environmental-policy.html
+++ b/web/src/content/environmental-policy.html
@@ -2,6 +2,9 @@
 layout: layouts/simple.njk
 tags:
   - tertiary
+seo:
+  title: Environmental Policy
+  description: How Draft & Flow reduces waste and supports sustainable cycling
 eleventyNavigation:
   key: Environmental Policy
   title: Environmental Policy

--- a/web/src/content/index.html
+++ b/web/src/content/index.html
@@ -2,6 +2,9 @@
 layout: layouts/home
 pageID: staticPages.home
 navtitle: Home
+seo:
+  title: Draft & Flow - Community Cycle Workshop
+  description: Aberfeldy's community workshop for bike repairs, routes and more
 eleventyComputed:
   description: 'A community-centred cycle workshop providing tools for DIY repairs, repair services, parts, bikes and hires, route info and more'
   title: 'Draft & Flow - Community Cycle Workshop - Aberfeldy'

--- a/web/src/content/local-routes/local-routes.html
+++ b/web/src/content/local-routes/local-routes.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-routes.jpg
 title: Local Routes
 tags:
   - main
+seo:
+  title: Aberfeldy Local Cycling Routes
+  description: Browse curated cycling routes around Aberfeldy and Highland Perthshire
 eleventyNavigation:
   parent: Local
   key: Local Routes

--- a/web/src/content/local-routes/route-pages.html
+++ b/web/src/content/local-routes/route-pages.html
@@ -11,6 +11,9 @@ pagination:
 permalink: local-routes/{{ route.slug }}/index.html
 eleventyComputed:
   title: "{{ route.title }}"
+  seo:
+    title: "{{ route.title }} | Cycling Route"
+    description: "{{ route.excerpt }}"
   eleventyNavigation:
     parent: Local Routes
     key: "{{ route.id }}"

--- a/web/src/content/membership/membership.html
+++ b/web/src/content/membership/membership.html
@@ -5,6 +5,9 @@ pageID: staticPages.memberships
 title: Membership
 tags:
   - secondary
+seo:
+  title: Community Workshop Membership
+  description: Support Draft & Flow and enjoy member benefits and discounts
 eleventyNavigation:
   key: Membership
   title: Membership

--- a/web/src/content/news/news.html
+++ b/web/src/content/news/news.html
@@ -4,6 +4,9 @@ title: News
 tags:
   - news
   - secondary
+seo:
+  title: Draft & Flow News
+  description: Updates, announcements and stories from the community workshop
 eleventyNavigation:
   title: News
   key: News

--- a/web/src/content/news/pages-news.html
+++ b/web/src/content/news/pages-news.html
@@ -17,6 +17,9 @@ eleventyComputed:
   bannerTextSubTitle: "{{ article.bannerText.subtitle | safe }}"
   firstImage: "{{ article.firstImage }}"
   description: "{{ article.seo.description | escape | safe }}"
+  seo:
+    title: "{{ article.seo.title | escape | safe }}"
+    description: "{{ article.seo.description | escape | safe }}"
   date: "{{ article.createdAt }}"
   updatedAt: "{{ article.updatedAt }}"
   eleventyNavigation:

--- a/web/src/content/newsletter/newsletter.html
+++ b/web/src/content/newsletter/newsletter.html
@@ -4,6 +4,9 @@ bannerImage: src/static/images/banner-newsletter.jpg
 title: Draft & Flow Flyer
 tags:
   - secondary
+seo:
+  title: Join the Draft & Flow Flyer Newsletter
+  description: Subscribe for the latest offers, events and community news
 eleventyNavigation:
   key: Newsletter
   title: Newsletter

--- a/web/src/content/privacy-policy.html
+++ b/web/src/content/privacy-policy.html
@@ -2,6 +2,9 @@
 layout: layouts/simple.njk
 tags:
   - tertiary
+seo:
+  title: Privacy Policy
+  description: Learn how Draft & Flow collects and uses personal information
 eleventyNavigation:
   key: Privacy Policy
   title: Privacy Policy

--- a/web/src/content/ride-responsibility-statement.html
+++ b/web/src/content/ride-responsibility-statement.html
@@ -2,6 +2,9 @@
 layout: layouts/simple.njk
 tags:
   - tertiary
+seo:
+  title: Ride Responsibility Statement
+  description: Understand our legal disclaimer for social rides organised by Draft & Flow
 eleventyNavigation:
   key: Ride Responsibility Statement
   title: Ride Responsibility Statement

--- a/web/src/content/shop/pages-categories.html
+++ b/web/src/content/shop/pages-categories.html
@@ -13,6 +13,9 @@ eleventyComputed:
   title: "{{ category.title }}"
   body: "{{ category.body }}"
   oneLiner: "{{ category.oneLiner }}"
+  seo:
+    title: "{{ category.title }} | Shop"
+    description: "{{ category.oneLiner }}"
   eleventyNavigation:
     parent: "Shop"
     key: "{{ category.categoryID }}"

--- a/web/src/content/shop/pages-products.html
+++ b/web/src/content/shop/pages-products.html
@@ -40,6 +40,10 @@
       return null
     },
     oneLiner: data => data.product.oneLiner,
+    seo: {
+      title: data => data.product.seo?.title || `${data.product.name}`,
+      description: data => data.product.seo?.description || data.product.oneLiner
+    },
     options: data => {
       const imageURL = require('../../../src/utils/shortcodes/shortcodeImageURL.js')
       if (!data.product.options) {

--- a/web/src/content/shop/pages-subcategories.html
+++ b/web/src/content/shop/pages-subcategories.html
@@ -18,6 +18,9 @@ eleventyComputed:
   banner:
     ref: "{{ subcategory.banner.ref }}"
     alt: "{{ subcategory.banner.alt }}"
+  seo:
+    title: "{{ subcategory.title }} | Shop"
+    description: "{{ subcategory.oneLiner }}"
   eleventyNavigation:
     parent: "{{ subcategory.parent.categoryID }}"
     key: "{{ subcategory.categoryID }}"

--- a/web/src/content/shop/shop.html
+++ b/web/src/content/shop/shop.html
@@ -3,6 +3,9 @@ layout: layouts/pages/shop/index.njk
 tags:
   - shop
 title: Shop
+seo:
+  title: Draft & Flow Shop
+  description: Buy cycling gear, bikes and accessories from our Aberfeldy shop
 eleventyNavigation:
   key: Shop
   title: Shop

--- a/web/src/content/terms-conditions.html
+++ b/web/src/content/terms-conditions.html
@@ -3,6 +3,9 @@ layout: layouts/simple.njk
 pageID: staticPages.about
 tags:
   - tertiary
+seo:
+  title: Terms & Conditions
+  description: The rules for using the Draft & Flow website and services
 eleventyNavigation:
   key: Terms & Conditions
   title: Terms & Conditions

--- a/web/src/content/volunteer/index.html
+++ b/web/src/content/volunteer/index.html
@@ -5,6 +5,9 @@ pageID: staticPages.volunteer
 title: Volunteer
 tags:
   - main
+seo:
+  title: Volunteer with Draft & Flow
+  description: Learn how you can help support cycling in our community
 eleventyNavigation:
   parent: Local
   key: Volunteer


### PR DESCRIPTION
## Summary
- ensure metadata.description always has a default
- read seo.description from templates if present

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68512b47dd0883268f7f1bb048078ea3