### PR TITLE
Fix JSON-LD images on home page

### DIFF
--- a/web/src/_includes/layouts/home.njk
+++ b/web/src/_includes/layouts/home.njk
@@ -239,9 +239,9 @@
   "@context": "https://schema.org",
   "@type": "BikeStore",
   "image": [
-    "https://example.com/photos/1x1/photo.jpg",
-    "https://example.com/photos/4x3/photo.jpg",
-    "https://example.com/photos/16x9/photo.jpg"
+    "{{ env.url + '/static/images/banner-bikes.jpg' }}",
+    "{{ env.url + '/static/images/banner-ebikes.jpg' }}",
+    "{{ env.url + '/static/images/banner-service.jpg' }}"
    ],
   "@id": "{{ metadata.url }}",
   "name": "{{ metadata.title | safe }}",


### PR DESCRIPTION
## Summary
- update home page BikeStore schema to use real image URLs

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68512b75ffec8326aca2809dcd57b202