### PR TITLE
Add Cycle to Work page

### DIFF
--- a/web/src/content/bikes/cycle-to-work/index.html
+++ b/web/src/content/bikes/cycle-to-work/index.html
@@ -1,0 +1,21 @@
+---
+layout: layouts/page.njk
+bannerImage: src/static/images/banner-bikes.jpg
+title: Cycle to Work Scheme
+tags:
+  - main
+eleventyNavigation:
+  parent: Bikes
+  key: Cycle to Work
+  title: Cycle to Work Scheme
+  order: 3
+---
+
+_**Save money on your next bike**_
+
+Draft & Flow can now supply bikes through the Cycle to Work scheme. This UK government initiative lets employees purchase a new bike and accessories tax‑free via their employer, paying monthly through salary deductions.
+
+If your workplace offers a Cycle to Work programme, get in touch and we’ll help you choose a bike and submit the paperwork. Unsure how it all works? Pop into the shop or drop us an email—we’re happy to explain the process and answer any questions.
+
+For more information on how the scheme works, see the [official Cycle to Work guidance](https://www.gov.uk/government/publications/cycle-to-work-scheme-implementation-guidance).
+

--- a/web/src/content/bikes/cycle-to-work/index.html
+++ b/web/src/content/bikes/cycle-to-work/index.html
@@ -13,9 +13,18 @@ eleventyNavigation:
 
 _**Save money on your next bike**_
 
-Draft & Flow can now supply bikes through the Cycle to Work scheme. This UK government initiative lets employees purchase a new bike and accessories tax‑free via their employer, paying monthly through salary deductions.
+Draft & Flow can supply bikes through the Cycle to Work scheme. This UK government initiative lets employees purchase a new bike and accessories tax‑free via their employer, paying monthly through salary deductions. By deducting the cost of the bike from your salary before tax (salary sacrifice), it reduces your taxable income and results in lower tax and National Insurance contributions. 
+
+## How it works
+- Employees choose a bike and accessories from participating retailers, and their employer then purchases the equipment. 
+- The cost is repaid through monthly deductions from the employee's gross salary (before tax and National Insurance). 
+- Because the repayments are made before tax, employees pay less Income Tax and National Insurance, effectively saving them money. 
+- While the bike is typically owned by the employer during the repayment period, employees often have the option to purchase it at a fair market value at the end of the agreement. 
+- The scheme encourages cycling for commuting, promotes healthier lifestyles, and can lead to significant cost savings on bikes and accessories. 
+- The scheme is generally available to all employees, and employers can register to participate. 
+- The scheme covers a wide range of bikes (including e-bikes and adapted bikes), cycling clothing, helmets, locks, lights, and other accessories. 
 
 If your workplace offers a Cycle to Work programme, get in touch and we’ll help you choose a bike and submit the paperwork. Unsure how it all works? Pop into the shop or drop us an email—we’re happy to explain the process and answer any questions.
 
-For more information on how the scheme works, see the [official Cycle to Work guidance](https://www.gov.uk/government/publications/cycle-to-work-scheme-implementation-guidance).
+For more information on how the scheme works, see the [official Cycle to Work guidance](https://www.cyclinguk.org/article/guide-cycle-work-scheme).
 

--- a/web/src/content/bikes/cycle-to-work/index.html
+++ b/web/src/content/bikes/cycle-to-work/index.html
@@ -26,5 +26,5 @@ Draft & Flow can supply bikes through the Cycle to Work scheme. This UK governme
 
 If your workplace offers a Cycle to Work programme, get in touch and we’ll help you choose a bike and submit the paperwork. Unsure how it all works? Pop into the shop or drop us an email—we’re happy to explain the process and answer any questions.
 
-For more information on how the scheme works, see the [official Cycle to Work guidance](https://www.cyclinguk.org/article/guide-cycle-work-scheme).
+For more information on how the scheme works, see the [Cycling UK's Cycle to Work guidance](https://www.cyclinguk.org/article/guide-cycle-work-scheme).
 


### PR DESCRIPTION
## Summary
- add a `Cycle to Work` page in the bikes section
- rename to `index.html` so the URL becomes `/bikes/cycle-to-work/`
- link to official UK guidance for more scheme information

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*


------
https://chatgpt.com/codex/tasks/task_e_6852465791d88326abb69868be6eec34