### PR TITLE
Replace newsletter form with Shopify signup

### DIFF
--- a/web/src/_includes/layouts/base/footer.njk
+++ b/web/src/_includes/layouts/base/footer.njk
@@ -40,7 +40,7 @@
             </h3>
             {% include 'src/_includes/layouts/includes/newsletterForm.njk' %}
         </div>
-        <div class="subscribe-notice hidden max-w-prose mx-auto text-center my-4 text-df-tan font-sans text-xs uppercase ">
+        <div class="subscribe-notice max-w-prose mx-auto text-center my-4 text-df-tan font-sans text-xs uppercase ">
             {% include 'src/_includes/layouts/includes/newsletterNotice.njk' %}
         </div>
     </div>
@@ -162,13 +162,3 @@
     </div> #}
 </footer>
 
-<script>
-    const subscribeEmail = document.querySelector('#subscribe .subscribe-email')
-    const subscribeNotice = document.querySelector('#subscribe .subscribe-notice')
-
-    subscribeEmail.addEventListener('input', (e) => {
-        if (e.target.validity.valid) {
-            subscribeNotice.classList.remove('hidden')
-        }
-    })
-</script>

--- a/web/src/_includes/layouts/includes/newsletterForm.njk
+++ b/web/src/_includes/layouts/includes/newsletterForm.njk
@@ -1,1 +1,1 @@
-<a href="https://store.draftandflow.com/#contact_form" class="cta large tan mt-4 sm:mt-0 mr-4">Subscribe</a>
+<a href="https://store.draftandflow.com/#contact_form" class="cta large tan mt-4 sm:mt-0 mr-4 lg:ml-4">Subscribe</a>

--- a/web/src/_includes/layouts/includes/newsletterForm.njk
+++ b/web/src/_includes/layouts/includes/newsletterForm.njk
@@ -1,10 +1,1 @@
-<!-- Begin Mailchimp Signup Form -->
-<form action="https://draftandflow.us11.list-manage.com/subscribe/post?u=253d11f969cf4a0ac266ad0b1&amp;id=9c5aaeb56f&amp;f_id=00a5a6e0f0" method="post" name="subscribe-form" class="max-w-prose text-xl font-black uppercase sm:flex sm:justify-center" target="_self">
-    <input type="email" value="" placeholder="Your Email Address" name="EMAIL" class="subscribe-email h-12 sm:h-auto bg-df-tan font-medium border-2 border-df-black px-4 w-full max-w-xs sm:w-96 sm:max-w-none sm:mr-4 lg:mx-4" required>
-    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true">
-        <input type="text" name="b_253d11f969cf4a0ac266ad0b1_9c5aaeb56f" tabindex="-1" value="">
-    </div>
-    <button type="submit" class="w-1/2 sm:w-auto mt-4 sm:mt-0 mr-4 cta large tan cursor-pointer">Subscribe</button>
-</form>
-<!--End mc_embed_signup-->
+<a href="https://store.draftandflow.com/#contact_form" class="cta large tan mt-4 sm:mt-0 mr-4">Subscribe</a>

--- a/web/src/_includes/layouts/includes/newsletterNotice.njk
+++ b/web/src/_includes/layouts/includes/newsletterNotice.njk
@@ -1,2 +1,2 @@
-<p class="mb-4">We take privacy very seriously. You may unsubscribe from emails at any time by clicking the link in the footer of our emails. For information about our privacy practices, please view our <a href="/privacy-policy/" target="_blank" class="hover:underline">Privacy Policy</a>.</p>
-<p>We use Mailchimp as our marketing platform. By submitting this form, you acknowledge that your information will be transferred to Mailchimp for processing. <a href="https://mailchimp.com/legal/" rel="noopener">Learn more about Mailchimp's privacy practices here.</a></p>
+<p class="mb-4">We take privacy very seriously. You may unsubscribe from emails at any time. For information about our privacy practices, please view our <a href="/privacy-policy/" target="_blank" class="hover:underline">Privacy Policy</a>.</p>
+<p>You will be redirected to our Shopify store to complete your signup.</p>

--- a/web/src/content/newsletter/newsletter.html
+++ b/web/src/content/newsletter/newsletter.html
@@ -15,9 +15,10 @@ eleventyNavigation:
 
 _**Subscribe for discounts, events, and more**_
 
-Get notified of discounts, events, news and more by subscribing to the {{ metadata.title }} Flyer. The weekly Flyer is the best way to stay in-the-know about our current sales, events and other happenings. 
 
-Simply enter your email address below, click Subscribe, and then check your email for a confirmation (you'll need to confirm to complete your subscription).
+Get notified of discounts, events, news and more by subscribing to the {{ metadata.title }} Flyer. The weekly Flyer is the best way to stay in-the-know about our current sales, events and other happenings.
+
+Click the button below to subscribe through our online store.
 
 <div class="flex flex-col items-center">
 {% include 'src/_includes/layouts/includes/newsletterForm.njk' %}


### PR DESCRIPTION
## Summary
- remove Mailchimp subscription form
- link to Shopify signup form instead
- update privacy notice
- adjust newsletter page copy

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6867bfc5d1348326825c6f2c4669b4cf