### PR TITLE
Fix Instagram data fetch crashing the build

### DIFF
--- a/web/src/_data/instagram.js
+++ b/web/src/_data/instagram.js
@@ -12,18 +12,26 @@ const requestOptions = {
 
 const posts = await fetch(`https://graph.instagram.com/me/media?fields=id,caption,permalink,media_url,thumbnail_url,media_type,timestamp,children{media_url}&limit=20&access_token=${process.env.INSTAGRAM_TOKEN}`, requestOptions)
   .then(response => response.json())
-  .then(result => result)
   // eslint-disable-next-line
   .catch(error => console.log('error', error))
 
+if (!posts || !posts.data) {
+  console.log('Instagram data unavailable, returning empty array')
+  return []
+}
+
 const postsWithSizes = await Promise.all(
-  await posts.data.map(async (post) => {
+  posts.data.map(async (post) => {
   const file = post.media_type === 'VIDEO' ? post.thumbnail_url : post.media_url
   const image = await fetch(file)
     .then(response => response.arrayBuffer())
     // eslint-disable-next-line
     .catch(error => console.log('error', error))
-  
+
+  if (!image) {
+    return null
+  }
+
   const buffer = Buffer.from(image, "utf-8")
   const dimensions = await imageSize(buffer)
 
@@ -43,7 +51,7 @@ fetch(`https://graph.instagram.com/refresh_access_token?grant_type=ig_refresh_to
 // eslint-disable-next-line
 .catch(error => console.log('error', error))
 
-  return postsWithSizes
+  return postsWithSizes.filter(Boolean)
 }
 
 


### PR DESCRIPTION
When the Instagram API call fails (expired token, network error, missing
env var), the catch handler returns undefined. Accessing .data on
undefined causes a TypeError that breaks the entire Eleventy build.

Add a guard to return an empty array when no data is available, and
filter out any individual posts that fail to fetch their image.

https://claude.ai/code/session_01LLS8SGk23Ab6ErQ4GNE8Pn