### PR TITLE
Update shop hours to Tues-Sat 9:30am-5pm

### DIFF
--- a/web/src/_includes/layouts/base/header.njk
+++ b/web/src/_includes/layouts/base/header.njk
@@ -153,7 +153,7 @@
   <div class="ticker-wrap">
     <div class="ticker">
       {# <div class="ticker-item">Closed May 20 - 31 for holidays</div> #}
-      <div class="ticker-item">Shop Open Wed - Fri | 2pm - 6pm</div>
+      <div class="ticker-item">Shop Open Tues, Wed, Fri, Sat | 9:30am - 5pm</div>
       <div class="ticker-item">Need assistance outside shop hours? {% svgIcon 'src/assets/icons/socialWhatsApp.svg', 'w-4 inline-block -mt-1' %} <a href="tel:{{ metadata.contact.phone }}" title="Phone: {{ metadata.contact.phone }}">{{metadata.contact.phone}}</a> or {% svgIcon 'src/assets/icons/socialEmail.svg', 'w-5 inline-block' %} <a href="mailto:{{metadata.contact.email}}">{{metadata.contact.email}}</a></div>
     </div>
   </div>

--- a/web/src/_includes/layouts/home.njk
+++ b/web/src/_includes/layouts/home.njk
@@ -270,33 +270,13 @@
     {
       "@type": "OpeningHoursSpecification",
       "dayOfWeek": [
-        "Monday",
-        "Tuesday"
-      ],
-      "opens": "11:30",
-      "closes": "22:00"
-    },
-    {
-      "@type": "OpeningHoursSpecification",
-      "dayOfWeek": [
+        "Tuesday",
         "Wednesday",
-        "Thursday",
-        "Friday"
+        "Friday",
+        "Saturday"
       ],
-      "opens": "11:30",
-      "closes": "23:00"
-    },
-    {
-      "@type": "OpeningHoursSpecification",
-      "dayOfWeek": "Saturday",
-      "opens": "16:00",
-      "closes": "23:00"
-    },
-    {
-      "@type": "OpeningHoursSpecification",
-      "dayOfWeek": "Sunday",
-      "opens": "16:00",
-      "closes": "22:00"
+      "opens": "09:30",
+      "closes": "17:00"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Updated the shop's operating hours across the website to reflect new business hours.

## Changes Made
- **Header ticker**: Updated the shop hours announcement from "Wed - Fri | 2pm - 6pm" to "Tues, Wed, Fri, Sat | 9:30am - 5pm"
- **Schema.org structured data**: Consolidated opening hours specification to a single entry covering Tuesday through Saturday, 9:30am to 5pm (09:30 - 17:00)
  - Removed separate entries for Monday-Tuesday, Wednesday-Friday, Saturday, and Sunday
  - Simplified to one unified schedule for the four operating days

## Implementation Details
The changes ensure consistency between the user-facing header announcement and the machine-readable schema.org markup used for search engines and other services. The new schedule reduces operating days from 7 to 4 days per week while extending morning hours and maintaining consistent afternoon closing time.

https://claude.ai/code/session_017F39QXywbdw1t88AzeQ8zi